### PR TITLE
Resolve critical error on Firefox

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,19 +3,28 @@
   "name": "huntr.dev GitHub Extension",
   "version": "0.1.1",
   "description": "View huntr.dev bounty rewards on GitHub as you browse code repositories.",
-  "content_scripts": [{
-    "js": ["js/background.js"],
-    "matches": ["https://github.com/*/*"]
-  }],
-  "permissions": ["webRequest"],
-  "web_accessible_resources": [
-      "html/bounty_tab.html"
+  "content_scripts": [
+    {
+      "js": [
+        "js/background.js"
+      ],
+      "matches": [
+        "https://github.com/*/*"
+      ]
+    }
   ],
-  "icons": {   
-      "16": "img/logo_16.png",
-      "24": "img/logo_24.png",
-      "32": "img/logo_32.png",
-      "48": "img/logo_48.png",
-      "128": "img/logo_128.png"
+  "permissions": [
+    "webRequest",
+    "https://mnk2smepzzdp5djxpbthzr6odq.appsync-api.eu-west-1.amazonaws.com/graphql"
+  ],
+  "web_accessible_resources": [
+    "html/bounty_tab.html"
+  ],
+  "icons": {
+    "16": "img/logo_16.png",
+    "24": "img/logo_24.png",
+    "32": "img/logo_32.png",
+    "48": "img/logo_48.png",
+    "128": "img/logo_128.png"
   }
 }


### PR DESCRIPTION
Hello!

## Pull request overview
* Added the AWS server to the `permissions` in `manifest.json`.

## Issue 1
As you may have noticed through #1, this extension no longer works. Crucially, this is because the extensions that are published still uses the following as the body for their request:
```js
       body: JSON.stringify({
            query: /* GraphQL */ `
            query GetBountyMetrics($url: AWSURL!) {
                getBountyMetrics(url: $url) {
                bounty_reward
                popularity_score
                merge_chance
                }
            }`,
            variables: {
                url
            }
        })
```
As you may know, this does not work anymore. This repository has adapted accordingly, and already uses (the working):
https://github.com/418sec/huntr-extension/blob/e6d085adeab6fe2d9cb8a9ead598f1adecd2ca96/js/background.js#L8-L21

So, the released extensions need updating.

## Issue 2
Upon forking this repository and uploading it as an extension locally, it works on Chrome, but not on Firefox. On the latter, I would constantly be greeted with `TypeError: NetworkError when attempting to fetch resource.`.

After some digging, I found out that Firefox is more strict with the `permissions` section in the manifest.json. I ended up placing the URL of the AWS server in the `permissions` field of the `manifest.json`, and the issue disappeared.

### What now?
I would advise merging this PR, and updating the Chrome and Firefox extensions.

tags: @benharvie @JamieSlome 
cc-ing because this information might be of interest to you: @rst10124492, @jaapmarcus, @geeknik

(Note that I also ran a formatter on the manifest.json, making it appear like there's more changes than just the one line)

- Tom Aarsen